### PR TITLE
Uncomment the ifdef clause

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -117,9 +117,6 @@ install-i18n: $(I18Nmsgs)
 #*******************************************************************************
 $(SOFILE): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared $(OBJS) -o $@
-ifdef LCLBLD
-	install -D $(SOFILE) $(LIBDIR)/$(SOFILE).$(APIVERSION)
-endif
 
 
 install-lib: $(SOFILE)

--- a/Makefile
+++ b/Makefile
@@ -117,9 +117,9 @@ install-i18n: $(I18Nmsgs)
 #*******************************************************************************
 $(SOFILE): $(OBJS)
 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared $(OBJS) -o $@
-# ifdef LCLBLD
+ifdef LCLBLD
 	install -D $(SOFILE) $(LIBDIR)/$(SOFILE).$(APIVERSION)
-#  endif
+endif
 
 
 install-lib: $(SOFILE)


### PR DESCRIPTION
otherwise the $(SOFILE) target tries to write outside the build directory, which is not appreciated when packaging the plugin.